### PR TITLE
add overload to begin() to specify i2c pins

### DIFF
--- a/src/HDC2080.cpp
+++ b/src/HDC2080.cpp
@@ -44,6 +44,11 @@ void HDC2080::begin(void)
 	Wire.begin();
 }
 
+void HDC2080::begin(int sda, int scl)
+{
+	Wire.begin(sda, scl);
+}
+
 float HDC2080::readTemp(void)
 {
 	uint8_t byte[2];

--- a/src/HDC2080.h
+++ b/src/HDC2080.h
@@ -43,6 +43,7 @@ class HDC2080
 public:
 	HDC2080(uint8_t addr);					  // Initialize the HDC2080
 	void begin(void);						  // Join I2C bus
+	void begin(int sda, int scl);	// Join I2C bus with specified SDA and SCL pins
 	float readTemp(void);					  // Returns the temperature in degrees C
 	uint8_t readTempOffsetAdjust(void);		  // Returns the offset adjust in binary
 	uint8_t setTempOffsetAdjust(uint8_t);	 // Set and return the offset adjust in binary


### PR DESCRIPTION
Hey, not sure if there's a better way to do this, but I needed to pass in custom SDA and SCL pins, so I created an overload for begin() that will call Wire.begin() with those pins passed in. Thought I'd make a PR if you think that'd be useful.