### PR TITLE
Temperature equation update

### DIFF
--- a/src/HDC2080.cpp
+++ b/src/HDC2080.cpp
@@ -69,7 +69,8 @@ float HDC2080::readTemp(void)
 	temp = byte[1];
 	temp = (temp << 8) | byte[0];
 	float f = temp;
-	f = ((f * 165.0f) / 65536.0f) - 40.0f;
+	//f = ((f * 165.0f) / 65536.0f) - (40.5 + 0.08 * (VDD - 1.8)); // if the sensor is powered with more than 1.8 V, replace the VDD with the power source voltage.
+	f = ((f * 165.0f) / 65536.0f) - 40.5;
 	return f;
 }
 

--- a/src/HDC2080.cpp
+++ b/src/HDC2080.cpp
@@ -69,8 +69,8 @@ float HDC2080::readTemp(void)
 	temp = byte[1];
 	temp = (temp << 8) | byte[0];
 	float f = temp;
-	//f = ((f * 165.0f) / 65536.0f) - (40.5 + 0.08 * (VDD - 1.8)); // if the sensor is powered with more than 1.8 V, replace the VDD with the power source voltage.
-	f = ((f * 165.0f) / 65536.0f) - 40.5;
+	//f = ((f * 165.0f) / 65536.0f) - (40.5f + 0.08f * (VDD - 1.8f)); // if the sensor is powered with more than 1.8 V, replace the VDD with the power source voltage.
+	f = ((f * 165.0f) / 65536.0f) - 40.5f;
 	return f;
 }
 


### PR DESCRIPTION
Following the HDC2080 datasheet, the equation to calculate the temperature (when the sensor is powered by more than 1.8V) is the following:

(value * 165.0 / 65536.0) - (40.5 + 0.08 * (VDD - 1.8))

The 0.08 is the TEMP PSRR

Note: the sensor is powered by 3.3V in the EXT4.

See page 18th https://www.ti.com/lit/ds/symlink/hdc2080.pdf